### PR TITLE
Fix prime script

### DIFF
--- a/prime/PKGBUILD
+++ b/prime/PKGBUILD
@@ -12,7 +12,7 @@ conflicts=('xf86-video-intel')
 source=('20-nvidia.conf'
         'prime')
 md5sums=('ffe202975804e6aae7b9c74fc963818d'
-         'b94bca41f054ab6bdd1e44063bd9acf3')
+         'deb195c50062d25a4b316b38e463cf84')
 
 package() {
   install -Dm644 ../20-nvidia.conf ${pkgdir}/usr/share/X11/xorg.conf.d/20-nvidia.conf

--- a/prime/prime
+++ b/prime/prime
@@ -1,3 +1,3 @@
- #!/bin/bash
+#!/bin/bash
  
 __NV_PRIME_RENDER_OFFLOAD=1 __VK_LAYER_NV_optimus=NVIDIA_only __GLX_VENDOR_LIBRARY_NAME=nvidia "$@"


### PR DESCRIPTION
Fixes error
```
 ~  prime
Failed to execute process '/usr/bin/prime'. Reason:
exec: Exec format error
The file '/usr/bin/prime' is marked as an executable but could not be run by the operating system.
```