### PR TITLE
libatomic_ops 7.8.0 fix install license

### DIFF
--- a/libatomic_ops/PKGBUILD
+++ b/libatomic_ops/PKGBUILD
@@ -1,7 +1,7 @@
 
 pkgname=libatomic_ops
 pkgver=7.8.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Provides semi-portable access to hardware-provided atomic memory update operations"
 arch=('x86_64')
 url="https://github.com/ivmai/libatomic_ops"
@@ -30,5 +30,5 @@ package() {
   cd ${pkgname}-${pkgver}
   make DESTDIR=${pkgdir} install
 
-  install -D -m644 doc/LICENSING.txt ${pkgdir}/usr/share/licenses/$pkgname/LICENSE
+  install -D -m644 LICENSE ${pkgdir}/usr/share/licenses/$pkgname/LICENSE
 }


### PR DESCRIPTION
License file was renamed and moved in upstream (./doc/LICENSING.txt -> ./LICENSE).