### PR TITLE
Patch libblockdev

### DIFF
--- a/libblockdev/PKGBUILD
+++ b/libblockdev/PKGBUILD
@@ -2,7 +2,7 @@
 pkgname=libblockdev
 pkgver=3.0.3
 _pkgver=3.0.3-1
-pkgrel=1
+pkgrel=2
 pkgdesc="C library supporting GObject introspection for manipulation of block devices."
 arch=('x86_64')
 url="http://storaged.org/libblockdev/"
@@ -11,14 +11,14 @@ depends=('btrfs-progs' 'cryptsetup' 'kmod' 'libbytesize' 'lvm2' 'nss' 'parted'
          'python3' 'systemd' 'util-linux' 'volume_key' 'mpfr' 'ndctl' 'libyaml' 'dmraid' 'libnvme')
 makedepends=('gobject-introspection' 'python3-six')
 source=("https://github.com/storaged-project/libblockdev/releases/download/${_pkgver}/${pkgname}-${pkgver}.tar.gz"
-        "https://github.com/rhinstaller/libblockdev/commit/50dec146ddd6c77f5989aa359a545ab676437169.diff")
+        "https://github.com/storaged-project/libblockdev/commit/2ae0d949eb87142b0212e5953a0e5ad1a146ed6b.diff")
 md5sums=('fb4cd3812b7b5a8f2bd950799fbd37f6'
-         '29730cf7f7fba8555ae8b0e3ab6b0e6d')
+         'ce5d91a81d67eb3ee8ed8df8b9c25fab')
 
 prepare() {
     cd ${pkgname}-${pkgver}
 
-    #patch -p1 -i ${srcdir}/50dec146ddd6c77f5989aa359a545ab676437169.diff
+    patch -p1 -i ${srcdir}/2ae0d949eb87142b0212e5953a0e5ad1a146ed6b.diff
 }
 
 build() {


### PR DESCRIPTION
Apply patch for malloc on NVMe devices

https://github.com/storaged-project/libblockdev/commit/2ae0d949eb87142b0212e5953a0e5ad1a146ed6b

https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/thread/MHQOCHIZKELIOW6USUAH4JYQBVWHF2XE/