### PR TITLE
libmicrohttpd removed private header

### DIFF
--- a/libmicrohttpd/PKGBUILD
+++ b/libmicrohttpd/PKGBUILD
@@ -27,8 +27,4 @@ build() {
 package() {
   cd ${pkgname}-${pkgver}
   make DESTDIR=${pkgdir} install
-
-  install -Dm644 src/include/platform.h ${pkgdir}/usr/include/$pkgname/platform.h
-
-  sed -i 's|Cflags: -I${includedir}|Cflags: -I${includedir} -I{includedir}/libmicrohttpd|' ${pkgdir}/usr/lib/pkgconfig/libmicrohttpd.pc
 }


### PR DESCRIPTION
platform.h is a private header. 
In any case it does not work without MHD_config.h, which is not installed.